### PR TITLE
Allow multiple images, allow relative paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-graphql-image",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A gatsby plugin for generating file nodes from remote image URLS in GraphQL API's",
   "main": "gatsby-node.js",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -20,8 +20,11 @@ npm i -D gatsby-plugin-graphql-image
 
 ## Available options
 
-`schemaName` - The typeName value of your graphql source from the gatsby-source-grapql plugin<br/>
-`imageFieldName` - The name of the field that contains your image URLs
+`images` - An array of objects with these options <br/>
+  - `schemaName` - The typeName value of your graphql source from the gatsby-source-grapql plugin <br/>
+  - `typeName` - The actual graphQL typeName (you can query `__typename` in GraphiQL to get the actual typeName)  <br/>
+  - `fieldName` - The name of the field that contains your image URLs <br/>
+  - `baseUrl` - (optional) A base url to use in case the values are not absolute paths
 
 ## Examples of usage
 
@@ -37,12 +40,15 @@ npm i -D gatsby-plugin-graphql-image
 {
   resolve: 'gatsby-plugin-graphql-image',
   options: {
-    schemaName: "ROCKETMAKERS",
-    imageFieldName: "imageUrl"
+    images: [
+      {
+        schemaName: 'ROCKETMAKERS',
+        typeName: 'ROCKETMAKERS_UploadFile',
+        fieldName: 'url',
+        baseUrl: 'https://rocketmakers.com',
+      },
+    ]
   }
 }
 ```
 
-## Limitations
-
-Currently only supports one imageFieldName. Would be nice for this to take an array instead :)


### PR DESCRIPTION
Hi,
I modified the plugin to allow multiple images and added an optional baseUrl in case the graphQL endpoint returns relative paths (like Strapi e.g.). I also added typeName as required option so that the graphql __typename will also be checked to make the filtering less aggressive.